### PR TITLE
Feature/refactor every conf

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -13,7 +13,19 @@ server.register({
     mongoUrl: 'localhost:27017/hapi-agenda',
     jobs: __dirname + '/jobs',
     processEvery: '5 seconds',
-    jsonApi: true
+    jsonApi: true,
+    every: {
+      'log-deu': {
+        interval: '5 minutes'
+      },
+      'say-error' : {
+        enabled: false
+      },
+      'log' : {
+        interval: '18 minutes',
+        enabled: true
+      }
+    }
   }
 }, function(err) {
 

--- a/example/index.js
+++ b/example/index.js
@@ -15,15 +15,8 @@ server.register({
     processEvery: '5 seconds',
     jsonApi: true,
     every: {
-      'log-deu': {
-        interval: '1 minutes'
-      },
       'say-error' : {
         enabled: false
-      },
-      'log' : {
-        interval: '18 minutes',
-        enabled: true
       }
     }
   }

--- a/example/index.js
+++ b/example/index.js
@@ -16,7 +16,7 @@ server.register({
     jsonApi: true,
     every: {
       'log-deu': {
-        interval: '5 minutes'
+        interval: '1 minutes'
       },
       'say-error' : {
         enabled: false

--- a/index.js
+++ b/index.js
@@ -58,8 +58,24 @@ exports.register = function(plugin, options, next) {
   });
 
   if (options.every) {
-    _.forIn(options.every, function(value, key) {
-      agenda.every(key, value);
+    _.forIn(options.every, function(opts, jobName) {
+      var interval = (typeof opts === 'string') ? opts : opts.interval;
+
+      console.log(jobName + ': ' + interval);
+
+      var enabled = (opts.enabled !== undefined)? opts.enabled : true;
+      
+      if(enabled == false)
+      {
+        return agenda.cancel({name: jobName}, function(err, numRemoved) {
+          if(err)
+          {
+            throw err;
+          }
+        });
+      }
+
+      agenda.every(jobName, interval);
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -60,13 +60,11 @@ exports.register = function(plugin, options, next) {
   if (options.every) {
     _.forIn(options.every, function(opts, jobName) {
       var interval = (typeof opts === 'string') ? opts : opts.interval;
-
-      console.log(jobName + ': ' + interval);
-
       var enabled = (opts.enabled !== undefined)? opts.enabled : true;
       
       if(enabled == false)
       {
+        console.log('canceling ' + jobName);
         return agenda.cancel({name: jobName}, function(err, numRemoved) {
           if(err)
           {
@@ -75,7 +73,7 @@ exports.register = function(plugin, options, next) {
         });
       }
 
-      agenda.every(jobName, interval);
+      agenda.every(interval, jobName);
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -64,7 +64,6 @@ exports.register = function(plugin, options, next) {
       
       if(enabled == false)
       {
-        console.log('Cancelling: ' + jobName);
         return agenda.cancel({name: jobName}, function(err, numRemoved) {
           if(err)
           {

--- a/index.js
+++ b/index.js
@@ -62,8 +62,7 @@ exports.register = function(plugin, options, next) {
       var interval = (typeof opts === 'string') ? opts : opts.interval;
       var enabled = (opts.enabled !== undefined)? opts.enabled : true;
       
-      if(enabled == false)
-      {
+      if (enabled == false) {
         return agenda.cancel({name: jobName}, function(err, numRemoved) {
           if(err)
           {

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ exports.register = function(plugin, options, next) {
       
       if(enabled == false)
       {
-        console.log('canceling ' + jobName);
+        console.log('Cancelling: ' + jobName);
         return agenda.cancel({name: jobName}, function(err, numRemoved) {
           if(err)
           {


### PR DESCRIPTION
Major update (breaking change)

Refactored configuration to accept params for every as follows:

```yaml
jobs:
  processEvery: '30 seconds'
  every:
    'csv-report':
        interval: '0 45 23 * * 6'
    'enable-cse-libraries': '6 hours'
    'circle-reminders':
       interval: '0 0 7 * * 4'
       enable: false
    'chapter-reminders':
       interval: '0 15 7 * * 4'
```

Where setting `enable: false` will call `agenda.cancel` to remove the job from the queue and stop it.